### PR TITLE
Correct CanHideGUI FFlag in Tips and Tricks

### DIFF
--- a/src/Configuration/tips-and-tricks/index.md
+++ b/src/Configuration/tips-and-tricks/index.md
@@ -23,7 +23,7 @@ This section is undocumented; below is a list of fflags that can be set. Credits
 
 ```toml
 # See https://github.com/pizzaboxer/bloxstrap/wiki/A-guide-to-FastFlags#gui-hiding
-DFIntCanHideGuiGroupId = true
+DFIntCanHideGuiGroupId = 32380007
 
 # See IGMenuVersions in Bloxstrap for more details
 FFlagDisableNewIGMinDUA = true


### PR DESCRIPTION
`true` isn't a valid option for this fflag, and doesn't do anything (no gui hiding). The fflag accepts a Roblox group ID, for example, we can use Bloxstrap's Roblox group here as they allow GUI hiding in that group.