### PR TITLE
Fix link to Block FAQ in index.html

### DIFF
--- a/src/Home/index.md
+++ b/src/Home/index.md
@@ -7,7 +7,7 @@
 [Roblox has discontinued Wine support for Roblox Player as of 22/02/2024](https://devforum.roblox.com/t/why-isnt-hyperion-an-anti-cheat/2840095/27?u=jrelvas). You will no longer be able to run Roblox Player. Please do not open bug reports about it, **there's nothing we can do.**
 <u>Roblox Studio should continue working.</u>
 
-Please see [the 2024 Roblox on Linux Block FAQ](./Home/rol_faq.md) for more information.
+Please see [the 2024 Roblox on Linux Block FAQ](/Home/rol_faq.md) for more information.
 </div>
 
 

--- a/src/Home/index.md
+++ b/src/Home/index.md
@@ -7,7 +7,7 @@
 [Roblox has discontinued Wine support for Roblox Player as of 22/02/2024](https://devforum.roblox.com/t/why-isnt-hyperion-an-anti-cheat/2840095/27?u=jrelvas). You will no longer be able to run Roblox Player. Please do not open bug reports about it, **there's nothing we can do.**
 <u>Roblox Studio should continue working.</u>
 
-Please see [the 2024 Roblox on Linux Block FAQ](./rol_faq.md) for more information.
+Please see [the 2024 Roblox on Linux Block FAQ](./Home/rol_faq.md) for more information.
 </div>
 
 


### PR DESCRIPTION
index.html is located at both [https://vinegarhq.org/index.html](url) and [https://vinegarhq.org/Home/index.html](url),
so the link to ./rol_faq.md only works if the link in the sidebar is clicked first.