### PR TITLE
Replace Vinegar with Sober

### DIFF
--- a/src/Sober/Installation/index.md
+++ b/src/Sober/Installation/index.md
@@ -22,7 +22,7 @@ Other requirements include:
 ### To install
 
 #### Through Flathub (recommended)
-Sober can be found on [Flathub](https://flathub.org/apps/org.vinegarhq.Vinegar):
+Sober can be found on [Flathub](https://flathub.org/apps/org.vinegarhq.Sober):
 
 <a href="https://flathub.org/apps/org.vinegarhq.Sober">
 	<img width="180" alt="Download on Flathub" src="https://dl.flathub.org/assets/badges/flathub-badge-en.png"/>


### PR DESCRIPTION
Fixed a link that pointed to Vinegar's Flathub page on Sober's installation page.