### PR TITLE
Add troubleshooting entry regarding crash on hybrid graphics

### DIFF
--- a/src/Sober/Troubleshooting/index.md
+++ b/src/Sober/Troubleshooting/index.md
@@ -254,4 +254,14 @@ If you want it at higher quality, append the following FFlags into the `"fflags"
 "DFFlagTextureQualityOverrideEnabled": true
 ```
 
+
 > Please keep in mind that if you are using an NVIDIA card with VRAM capacity less than 4 GB, please be mindful of the [OutOfMemory crash](#rbxcrash-outofmemory-failed-to-allocate-memory-size--x-alignment--y) when attempting to play as it will render **all** textures at the highest quality possible. Proceed at your own risk.
+
+
+### Sober crashes on hybrid graphics with the following error: `vkGetPhysicalDeviceSurfacePresentModesKHR failed`
+
+This is mainly an issue on laptops with NVIDIA GPUs, where Sober is unable to wake up the discrete GPU for unknown reasons. It is said to be a problem with the latest NVIDIA drivers.
+
+#### Solution
+
+Run an application utilizing Vulkan (e.g. vkcube) in order to wake up the discrete GPU. Sober should be able to launch afterwards.


### PR DESCRIPTION
This mainly affects laptops with NVIDIA GPUs, where Sober isn't able to wake up the discrete GPU for whatever reason.