### PR TITLE
fixed description for GrassMovementReducedMotionFactor

### DIFF
--- a/src/Sober/Configuration/TipsAndTricks.md
+++ b/src/Sober/Configuration/TipsAndTricks.md
@@ -59,7 +59,8 @@ If you intend to use the perfer Vulkan/OpenGL flags, we recommend running `flatp
 ### User interface Fast Flags
 | FFlag Name                                    | Type          | Description                                                               | Accepted Values    |
 | --------------------------------------------- | ------------- | ------------------------------------------------------------------------- | ------------------ |
-| `FIntGrassMovementReducedMotionFactor`        | bool          | Reduces motion for grass                                                  | true/false         |
+| `FIntGrassMovementReducedMotionFactor`        | bool          | Grass motion frequency (supposedly, but does not work)
+                                                  | 0-1000         |
 
 ## Latest Mesa drivers
 

--- a/src/Sober/Configuration/TipsAndTricks.md
+++ b/src/Sober/Configuration/TipsAndTricks.md
@@ -59,7 +59,7 @@ If you intend to use the perfer Vulkan/OpenGL flags, we recommend running `flatp
 ### User interface Fast Flags
 | FFlag Name                                    | Type          | Description                                                               | Accepted Values    |
 | --------------------------------------------- | ------------- | ------------------------------------------------------------------------- | ------------------ |
-| `FIntGrassMovementReducedMotionFactor`        | bool          | Grass motion frequency (supposedly, but does not work)
+| `FIntGrassMovementReducedMotionFactor`        | integer          | Grass motion frequency (supposedly, but does not work)
                                                   | 0-1000         |
 
 ## Latest Mesa drivers


### PR DESCRIPTION
It was incorrectly typed as a boolean despite being a fast integer flag (`FInt`). The Fishstrap Discord server had the same issue, but was identified and fixed.

As a side note, this flag is expected to affect grass motion speed: a higher value means faster motion, while a lower value means slower motion. This was last tested a long time ago, so the behavior may have changed.